### PR TITLE
feat: redesign admin god mode control center

### DIFF
--- a/admin/ads.php
+++ b/admin/ads.php
@@ -116,17 +116,23 @@ $page_title = 'Ad Management - Admin Panel';
 include 'includes/admin_header.php';
 ?>
 
-<div class="container-fluid">
-    <div class="row">
-        <?php include 'includes/admin_sidebar.php'; ?>
-        
-        <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
-            <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-                <h1 class="h2">Ad Management</h1>
-                <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addAdModal">
-                    <i class="fas fa-plus"></i> Add New Ad
-                </button>
+<?php include 'includes/admin_sidebar.php'; ?>
+
+<main class="admin-main">
+    <div class="admin-page-header">
+        <div>
+            <div class="admin-breadcrumb">
+                <i class="fas fa-ad text-primary"></i>
+                <span>Revenue</span>
+                <span class="text-muted">Ad Control</span>
             </div>
+            <h1>Ad Command Center</h1>
+            <p class="text-muted mb-0">Deploy, pause, and optimize every placement in one view.</p>
+        </div>
+        <button class="btn btn-primary shadow-hover" data-bs-toggle="modal" data-bs-target="#addAdModal">
+            <i class="fas fa-plus"></i> Add New Ad
+        </button>
+    </div>
 
             <?php if ($success_message): ?>
                 <div class="alert alert-success"><?php echo htmlspecialchars($success_message); ?></div>
@@ -136,9 +142,8 @@ include 'includes/admin_header.php';
                 <div class="alert alert-danger"><?php echo htmlspecialchars($error_message); ?></div>
             <?php endif; ?>
 
-            <!-- Ads List -->
-            <div class="card">
-                <div class="card-body">
+    <!-- Ads List -->
+    <div class="admin-content-wrapper">
                     <?php if (!empty($ads)): ?>
                         <div class="table-responsive">
                             <table class="table table-striped">
@@ -210,11 +215,8 @@ include 'includes/admin_header.php';
                             </button>
                         </div>
                     <?php endif; ?>
-                </div>
-            </div>
-        </main>
     </div>
-</div>
+</main>
 
 <!-- Add Ad Modal -->
 <div class="modal fade" id="addAdModal" tabindex="-1">

--- a/admin/analytics.php
+++ b/admin/analytics.php
@@ -98,92 +98,83 @@ $page_title = 'Analytics - Admin Panel';
 include 'includes/admin_header.php';
 ?>
 
-<div class="container-fluid">
-    <div class="row">
-        <?php include 'includes/admin_sidebar.php'; ?>
-        
-        <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
-            <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-                <h1 class="h2">Analytics Dashboard</h1>
-                <div class="btn-group">
-                    <a href="?period=7" class="btn btn-sm <?php echo $period == '7' ? 'btn-primary' : 'btn-outline-primary'; ?>">7 Days</a>
-                    <a href="?period=30" class="btn btn-sm <?php echo $period == '30' ? 'btn-primary' : 'btn-outline-primary'; ?>">30 Days</a>
-                    <a href="?period=90" class="btn btn-sm <?php echo $period == '90' ? 'btn-primary' : 'btn-outline-primary'; ?>">90 Days</a>
-                    <a href="?period=365" class="btn btn-sm <?php echo $period == '365' ? 'btn-primary' : 'btn-outline-primary'; ?>">1 Year</a>
+<?php include 'includes/admin_sidebar.php'; ?>
+
+<main class="admin-main">
+    <div class="admin-page-header">
+        <div>
+            <div class="admin-breadcrumb">
+                <i class="fas fa-chart-line text-primary"></i>
+                <span>Insights</span>
+                <span class="text-muted">Analytics</span>
+            </div>
+            <h1>Analytics Command</h1>
+            <p class="text-muted mb-0">Visualize growth and quality signals across the network.</p>
+        </div>
+        <div class="btn-group shadow-sm">
+            <a href="?period=7" class="btn btn-sm <?php echo $period == '7' ? 'btn-primary' : 'btn-outline-primary'; ?>">7 Days</a>
+            <a href="?period=30" class="btn btn-sm <?php echo $period == '30' ? 'btn-primary' : 'btn-outline-primary'; ?>">30 Days</a>
+            <a href="?period=90" class="btn btn-sm <?php echo $period == '90' ? 'btn-primary' : 'btn-outline-primary'; ?>">90 Days</a>
+            <a href="?period=365" class="btn btn-sm <?php echo $period == '365' ? 'btn-primary' : 'btn-outline-primary'; ?>">1 Year</a>
+        </div>
+    </div>
+
+    <!-- Engagement Stats -->
+    <div class="row g-4 mb-4">
+        <div class="col-xl-3 col-md-6">
+            <div class="admin-metric-card h-100">
+                <div class="d-flex justify-content-between align-items-start">
+                    <div>
+                        <p class="metric-label">Weekly Active Users</p>
+                        <p class="metric-value mb-1"><?php echo number_format($engagement['weekly_active']); ?></p>
+                        <span class="metric-trend up"><i class="fas fa-users"></i>Fresh energy weekly</span>
+                    </div>
+                    <span class="icon-wrapper"><i class="fas fa-users"></i></span>
                 </div>
             </div>
-
-            <!-- Engagement Stats -->
-            <div class="row mb-4">
-                <div class="col-xl-3 col-md-6 mb-4">
-                    <div class="card border-left-primary shadow h-100 py-2">
-                        <div class="card-body">
-                            <div class="row no-gutters align-items-center">
-                                <div class="col mr-2">
-                                    <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Weekly Active Users</div>
-                                    <div class="h5 mb-0 font-weight-bold text-gray-800"><?php echo number_format($engagement['weekly_active']); ?></div>
-                                </div>
-                                <div class="col-auto">
-                                    <i class="fas fa-users fa-2x text-gray-300"></i>
-                                </div>
-                            </div>
-                        </div>
+        </div>
+        <div class="col-xl-3 col-md-6">
+            <div class="admin-metric-card h-100">
+                <div class="d-flex justify-content-between align-items-start">
+                    <div>
+                        <p class="metric-label">Monthly Active Users</p>
+                        <p class="metric-value mb-1"><?php echo number_format($engagement['monthly_active']); ?></p>
+                        <span class="metric-trend up"><i class="fas fa-user-check"></i>Retention momentum</span>
                     </div>
-                </div>
-
-                <div class="col-xl-3 col-md-6 mb-4">
-                    <div class="card border-left-success shadow h-100 py-2">
-                        <div class="card-body">
-                            <div class="row no-gutters align-items-center">
-                                <div class="col mr-2">
-                                    <div class="text-xs font-weight-bold text-success text-uppercase mb-1">Monthly Active Users</div>
-                                    <div class="h5 mb-0 font-weight-bold text-gray-800"><?php echo number_format($engagement['monthly_active']); ?></div>
-                                </div>
-                                <div class="col-auto">
-                                    <i class="fas fa-user-check fa-2x text-gray-300"></i>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="col-xl-3 col-md-6 mb-4">
-                    <div class="card border-left-info shadow h-100 py-2">
-                        <div class="card-body">
-                            <div class="row no-gutters align-items-center">
-                                <div class="col mr-2">
-                                    <div class="text-xs font-weight-bold text-info text-uppercase mb-1">Weekly Reviews</div>
-                                    <div class="h5 mb-0 font-weight-bold text-gray-800"><?php echo number_format($engagement['weekly_reviews']); ?></div>
-                                </div>
-                                <div class="col-auto">
-                                    <i class="fas fa-comments fa-2x text-gray-300"></i>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="col-xl-3 col-md-6 mb-4">
-                    <div class="card border-left-warning shadow h-100 py-2">
-                        <div class="card-body">
-                            <div class="row no-gutters align-items-center">
-                                <div class="col mr-2">
-                                    <div class="text-xs font-weight-bold text-warning text-uppercase mb-1">Weekly Votes</div>
-                                    <div class="h5 mb-0 font-weight-bold text-gray-800"><?php echo number_format($engagement['weekly_votes']); ?></div>
-                                </div>
-                                <div class="col-auto">
-                                    <i class="fas fa-thumbs-up fa-2x text-gray-300"></i>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <span class="icon-wrapper"><i class="fas fa-user-check"></i></span>
                 </div>
             </div>
+        </div>
+        <div class="col-xl-3 col-md-6">
+            <div class="admin-metric-card h-100">
+                <div class="d-flex justify-content-between align-items-start">
+                    <div>
+                        <p class="metric-label">Weekly Reviews</p>
+                        <p class="metric-value mb-1"><?php echo number_format($engagement['weekly_reviews']); ?></p>
+                        <span class="metric-trend up"><i class="fas fa-comments"></i>Community voice</span>
+                    </div>
+                    <span class="icon-wrapper"><i class="fas fa-comments"></i></span>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6">
+            <div class="admin-metric-card h-100">
+                <div class="d-flex justify-content-between align-items-start">
+                    <div>
+                        <p class="metric-label">Weekly Votes</p>
+                        <p class="metric-value mb-1"><?php echo number_format($engagement['weekly_votes']); ?></p>
+                        <span class="metric-trend up"><i class="fas fa-thumbs-up"></i>Trust interactions</span>
+                    </div>
+                    <span class="icon-wrapper"><i class="fas fa-thumbs-up"></i></span>
+                </div>
+            </div>
+        </div>
+    </div>
 
             <!-- Activity Chart -->
             <div class="row">
                 <div class="col-xl-8 col-lg-7">
-                    <div class="card shadow mb-4">
+                    <div class="card admin-content-wrapper shadow mb-4">
                         <div class="card-header py-3">
                             <h6 class="m-0 font-weight-bold text-primary">Activity Overview (Last <?php echo $period; ?> Days)</h6>
                         </div>
@@ -194,7 +185,7 @@ include 'includes/admin_header.php';
                 </div>
 
                 <div class="col-xl-4 col-lg-5">
-                    <div class="card shadow mb-4">
+                    <div class="card admin-content-wrapper shadow mb-4">
                         <div class="card-header py-3">
                             <h6 class="m-0 font-weight-bold text-primary">Top Performing Sites</h6>
                         </div>
@@ -222,7 +213,7 @@ include 'includes/admin_header.php';
             </div>
 
             <!-- Recent Transactions -->
-            <div class="card shadow mb-4">
+            <div class="card admin-content-wrapper shadow mb-4">
                 <div class="card-header py-3">
                     <h6 class="m-0 font-weight-bold text-primary">Recent Deposit Transactions</h6>
                 </div>
@@ -278,9 +269,7 @@ include 'includes/admin_header.php';
                     <?php endif; ?>
                 </div>
             </div>
-        </main>
-    </div>
-</div>
+</main>
 
 <script>
 // Activity Chart

--- a/admin/assets/css/theme.css
+++ b/admin/assets/css/theme.css
@@ -1,0 +1,537 @@
+:root {
+    --admin-font-family: 'Inter', 'Nunito Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    --admin-font-size-base: 0.95rem;
+    --admin-bg: #f8fafc;
+    --admin-surface: #ffffff;
+    --admin-surface-muted: #eef2ff;
+    --admin-text: #0f172a;
+    --admin-text-muted: #64748b;
+    --admin-border: rgba(15, 23, 42, 0.08);
+    --admin-primary: #4f46e5;
+    --admin-primary-dark: #4338ca;
+    --admin-secondary: #6b7280;
+    --admin-success: #22c55e;
+    --admin-danger: #ef4444;
+    --admin-warning: #f59e0b;
+    --admin-info: #0ea5e9;
+    --admin-sidebar-bg: #111827;
+    --admin-sidebar-active: rgba(79, 70, 229, 0.18);
+    --admin-sidebar-hover: rgba(79, 70, 229, 0.3);
+    --admin-navbar-gradient: linear-gradient(120deg, #4f46e5, #7c3aed);
+    --admin-card-shadow: 0 18px 45px -25px rgba(15, 23, 42, 0.45);
+    --admin-glow-shadow: 0 0 0 3px rgba(79, 70, 229, 0.15);
+    --admin-radius-lg: 1.25rem;
+    --admin-radius-md: 1rem;
+    --admin-radius-sm: 0.75rem;
+}
+
+html[data-theme="dark"] {
+    --admin-bg: #0f172a;
+    --admin-surface: rgba(15, 23, 42, 0.65);
+    --admin-surface-muted: rgba(79, 70, 229, 0.1);
+    --admin-text: #e2e8f0;
+    --admin-text-muted: #94a3b8;
+    --admin-border: rgba(148, 163, 184, 0.12);
+    --admin-sidebar-bg: rgba(15, 23, 42, 0.85);
+    --admin-sidebar-active: rgba(79, 70, 229, 0.35);
+    --admin-sidebar-hover: rgba(79, 70, 229, 0.45);
+    --admin-card-shadow: 0 18px 45px -25px rgba(15, 23, 42, 0.8);
+    background: var(--admin-bg);
+}
+
+html {
+    background: var(--admin-bg);
+}
+
+body {
+    font-family: var(--admin-font-family);
+    font-size: var(--admin-font-size-base);
+    background: var(--admin-bg);
+    color: var(--admin-text);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.admin-app {
+    background: var(--admin-bg);
+    color: var(--admin-text);
+}
+
+.admin-navbar {
+    background-image: var(--admin-navbar-gradient);
+    border: none;
+    box-shadow: 0 10px 30px -15px rgba(79, 70, 229, 0.7);
+    padding: 0.75rem 1.5rem;
+}
+
+.admin-navbar .navbar-brand {
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+}
+
+.admin-navbar .navbar-brand .brand-initial {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.18);
+    color: #fff;
+    font-weight: 700;
+}
+
+.admin-navbar .form-control {
+    border-radius: 999px;
+    border: none;
+    padding-inline: 1.25rem;
+    min-width: 260px;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+    background: rgba(15, 23, 42, 0.15);
+    color: #fff;
+}
+
+.admin-navbar .form-control::placeholder {
+    color: rgba(226, 232, 240, 0.7);
+}
+
+.admin-navbar .form-control:focus {
+    background: rgba(255, 255, 255, 0.12);
+    box-shadow: 0 0 0 0.2rem rgba(255, 255, 255, 0.08);
+}
+
+.admin-navbar .nav-link,
+.admin-navbar .dropdown-toggle,
+.admin-navbar .navbar-text {
+    color: rgba(255, 255, 255, 0.88) !important;
+}
+
+.admin-navbar .dropdown-menu {
+    border-radius: var(--admin-radius-md);
+    border: 1px solid rgba(148, 163, 184, 0.12);
+    box-shadow: var(--admin-card-shadow);
+    background: var(--admin-surface);
+    color: var(--admin-text);
+}
+
+.admin-navbar .dropdown-item {
+    border-radius: 0.65rem;
+}
+
+.admin-navbar .dropdown-item:hover {
+    background: var(--admin-surface-muted);
+}
+
+.theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    color: #fff;
+    border: none;
+    background: rgba(15, 23, 42, 0.18);
+    transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+}
+
+.theme-toggle:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 25px -12px rgba(15, 23, 42, 0.65);
+    background: rgba(255, 255, 255, 0.18);
+}
+
+.admin-layout {
+    flex: 1;
+    display: flex;
+    width: 100%;
+    min-height: calc(100vh - 72px);
+    position: relative;
+}
+
+.admin-sidebar {
+    background: var(--admin-sidebar-bg);
+    color: rgba(226, 232, 240, 0.9);
+    min-width: 240px;
+    max-width: 260px;
+    transition: all 0.3s ease;
+    padding: 1.5rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    position: relative;
+    z-index: 1030;
+}
+
+.admin-sidebar .sidebar-title {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: rgba(148, 163, 184, 0.7);
+    margin-bottom: 0.75rem;
+    padding-inline: 1rem;
+}
+
+.admin-sidebar .nav-link {
+    color: rgba(226, 232, 240, 0.85);
+    border-radius: var(--admin-radius-sm);
+    padding: 0.65rem 0.95rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-weight: 500;
+    transition: background 0.25s ease, transform 0.25s ease;
+}
+
+.admin-sidebar .nav-link .icon-wrapper {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 10px;
+    background: rgba(79, 70, 229, 0.2);
+    color: #a5b4fc;
+}
+
+.admin-sidebar .nav-link:hover {
+    background: var(--admin-sidebar-hover);
+    transform: translateX(4px);
+}
+
+.admin-sidebar .nav-link.active {
+    background: var(--admin-sidebar-active);
+    color: #fff !important;
+    box-shadow: 0 12px 25px -18px rgba(79, 70, 229, 0.75);
+}
+
+.admin-sidebar .nav-link.active .icon-wrapper {
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+}
+
+.admin-sidebar .nav-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.admin-sidebar .sidebar-footer {
+    margin-top: auto;
+    padding: 1rem;
+    background: rgba(15, 23, 42, 0.45);
+    border-radius: var(--admin-radius-md);
+    font-size: 0.8rem;
+}
+
+.admin-sidebar .badge {
+    background: rgba(79, 70, 229, 0.25);
+    color: #c7d2fe;
+    font-size: 0.7rem;
+    border-radius: 999px;
+}
+
+.admin-main {
+    flex: 1;
+    background: var(--admin-bg);
+    border-top-left-radius: var(--admin-radius-lg);
+    padding: 1.5rem 2rem;
+    position: relative;
+    overflow-x: hidden;
+}
+
+.admin-main::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(circle at top right, rgba(79, 70, 229, 0.12), transparent 45%),
+                radial-gradient(circle at 40% 120%, rgba(14, 165, 233, 0.08), transparent 55%);
+    opacity: 0.75;
+}
+
+.admin-main > * {
+    position: relative;
+    z-index: 2;
+}
+
+.admin-content-wrapper {
+    background: var(--admin-surface);
+    border-radius: var(--admin-radius-lg);
+    padding: 1.75rem;
+    box-shadow: var(--admin-card-shadow);
+    border: 1px solid var(--admin-border);
+    margin-bottom: 2rem;
+}
+
+.admin-page-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+    gap: 1rem;
+}
+
+.admin-page-header h1 {
+    font-weight: 700;
+    font-size: 1.35rem;
+    margin: 0;
+}
+
+.admin-breadcrumb {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    background: var(--admin-surface-muted);
+    border-radius: 999px;
+    padding: 0.45rem 1rem;
+    font-size: 0.8rem;
+    color: var(--admin-text-muted);
+}
+
+.admin-metric-card {
+    background: var(--admin-surface);
+    border-radius: var(--admin-radius-lg);
+    padding: 1.5rem;
+    border: 1px solid var(--admin-border);
+    box-shadow: 0 25px 35px -30px rgba(15, 23, 42, 0.75);
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.admin-metric-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 30px 40px -25px rgba(79, 70, 229, 0.45);
+}
+
+.admin-metric-card .metric-label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--admin-text-muted);
+}
+
+.admin-metric-card .metric-value {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--admin-text);
+}
+
+.admin-metric-card .metric-trend {
+    font-size: 0.8rem;
+    margin-top: 0.75rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    border-radius: 999px;
+    padding: 0.3rem 0.8rem;
+}
+
+.metric-trend.up {
+    background: rgba(34, 197, 94, 0.15);
+    color: var(--admin-success);
+}
+
+.metric-trend.down {
+    background: rgba(239, 68, 68, 0.15);
+    color: var(--admin-danger);
+}
+
+.table {
+    color: var(--admin-text);
+}
+
+.table thead {
+    background: var(--admin-surface-muted);
+    border-bottom: none;
+}
+
+.table thead th {
+    border: none;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: var(--admin-text-muted);
+}
+
+.table tbody td {
+    border-color: var(--admin-border);
+    vertical-align: middle;
+}
+
+.table-hover tbody tr:hover {
+    background: rgba(79, 70, 229, 0.07);
+}
+
+.card, .list-group-item, .modal-content {
+    background: var(--admin-surface);
+    color: var(--admin-text);
+    border-radius: var(--admin-radius-md);
+    border: 1px solid var(--admin-border);
+}
+
+.badge-soft {
+    background: rgba(79, 70, 229, 0.18);
+    color: var(--admin-primary);
+    border-radius: 999px;
+    font-weight: 500;
+    padding: 0.25rem 0.65rem;
+}
+
+.badge-soft-success {
+    background: rgba(34, 197, 94, 0.18);
+    color: var(--admin-success);
+}
+
+.badge-soft-danger {
+    background: rgba(239, 68, 68, 0.18);
+    color: var(--admin-danger);
+}
+
+.admin-footer {
+    margin-top: auto;
+    background: var(--admin-surface);
+    border-top: 1px solid var(--admin-border);
+    padding: 1rem 2rem;
+    font-size: 0.85rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1rem;
+    z-index: 10;
+}
+
+.admin-footer .status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    border-radius: 999px;
+    padding: 0.35rem 0.85rem;
+    background: rgba(34, 197, 94, 0.12);
+    color: var(--admin-success);
+}
+
+.scroll-shadow {
+    position: relative;
+    overflow: auto;
+}
+
+.scroll-shadow::after {
+    content: '';
+    position: sticky;
+    bottom: 0;
+    height: 16px;
+    display: block;
+    background: linear-gradient(transparent, var(--admin-surface));
+    pointer-events: none;
+}
+
+.table-responsive {
+    border-radius: var(--admin-radius-md);
+    border: 1px solid var(--admin-border);
+    background: var(--admin-surface);
+}
+
+.shadow-hover {
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.shadow-hover:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--admin-card-shadow);
+}
+
+@media (max-width: 991.98px) {
+    .admin-navbar .form-control {
+        min-width: 180px;
+    }
+
+    .admin-layout {
+        flex-direction: column;
+    }
+
+    .admin-sidebar {
+        position: fixed;
+        inset: 0;
+        top: 72px;
+        max-width: 280px;
+        transform: translateX(-100%);
+        height: calc(100vh - 72px);
+        overflow-y: auto;
+        border-top-right-radius: var(--admin-radius-lg);
+        border-bottom-right-radius: var(--admin-radius-lg);
+        box-shadow: 40px 0 60px -40px rgba(15, 23, 42, 0.65);
+    }
+
+    .admin-sidebar.show {
+        transform: translateX(0);
+    }
+
+    .admin-main {
+        padding: 1.5rem 1.25rem 4rem;
+    }
+}
+
+@media (max-width: 575.98px) {
+    .admin-navbar {
+        padding: 0.75rem 1rem;
+    }
+
+    .admin-navbar .form-control {
+        width: 100%;
+        min-width: unset;
+    }
+
+    .admin-navbar .navbar-brand span {
+        display: none;
+    }
+
+    .admin-main {
+        padding: 1.25rem 1rem 4rem;
+    }
+
+    .admin-content-wrapper {
+        padding: 1.25rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.001ms !important;
+        scroll-behavior: auto !important;
+    }
+}
+
+.border-left-primary {
+    border-left: 0.25rem solid var(--admin-primary) !important;
+}
+
+.border-left-success {
+    border-left: 0.25rem solid var(--admin-success) !important;
+}
+
+.border-left-info {
+    border-left: 0.25rem solid var(--admin-info) !important;
+}
+
+.border-left-warning {
+    border-left: 0.25rem solid var(--admin-warning) !important;
+}
+
+.border-left-danger {
+    border-left: 0.25rem solid var(--admin-danger) !important;
+}
+
+.text-gray-800 {
+    color: var(--admin-text) !important;
+}
+
+.text-gray-300 {
+    color: rgba(148, 163, 184, 0.6) !important;
+}

--- a/admin/includes/admin_footer.php
+++ b/admin/includes/admin_footer.php
@@ -1,9 +1,18 @@
-<!-- Bootstrap 5 JS -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    
-    <!-- Custom Admin JS -->
+    </div>
+    <footer class="admin-footer">
+        <div>
+            &copy; <?php echo date('Y'); ?> <?php echo SITE_NAME; ?>. All rights reserved.
+        </div>
+        <div class="d-flex align-items-center gap-3">
+            <span class="status-pill"><i class="fas fa-circle"></i> Live</span>
+            <span>PHP <?php echo phpversion(); ?></span>
+            <span>Server time: <?php echo date('H:i'); ?></span>
+        </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+
     <script>
-        // Auto-hide alerts after 5 seconds
         document.addEventListener('DOMContentLoaded', function() {
             const alerts = document.querySelectorAll('.alert');
             alerts.forEach(function(alert) {
@@ -14,36 +23,102 @@
                     }, 300);
                 }, 5000);
             });
-        });
 
-        // Confirm delete actions
-        document.addEventListener('click', function(e) {
-            if (e.target.classList.contains('btn-danger') || e.target.closest('.btn-danger')) {
-                if (!confirm('Are you sure you want to delete this item? This action cannot be undone.')) {
-                    e.preventDefault();
+            document.addEventListener('click', function(e) {
+                if (e.target.classList.contains('btn-danger') || (e.target.closest && e.target.closest('.btn-danger'))) {
+                    if (!confirm('Are you sure you want to delete this item? This action cannot be undone.')) {
+                        e.preventDefault();
+                    }
                 }
+            });
+
+            const themeToggle = document.getElementById('themeToggle');
+            const updateThemeIcon = function(theme) {
+                if (!themeToggle) return;
+                const icon = themeToggle.querySelector('i');
+                if (!icon) return;
+                if (theme === 'dark') {
+                    icon.classList.remove('fa-moon');
+                    icon.classList.add('fa-sun');
+                } else {
+                    icon.classList.remove('fa-sun');
+                    icon.classList.add('fa-moon');
+                }
+            };
+
+            const applyTheme = function(theme) {
+                document.documentElement.setAttribute('data-theme', theme);
+                localStorage.setItem('admin-theme', theme);
+                updateThemeIcon(theme);
+            };
+
+            if (themeToggle) {
+                const initialTheme = document.documentElement.getAttribute('data-theme') || 'light';
+                updateThemeIcon(initialTheme);
+                themeToggle.addEventListener('click', function() {
+                    const current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+                    applyTheme(current);
+                });
+            }
+
+            const sidebar = document.getElementById('sidebarMenu');
+            const sidebarToggle = document.getElementById('sidebarToggle');
+            if (sidebar && sidebarToggle) {
+                const overlay = document.createElement('div');
+                overlay.className = 'position-fixed top-0 start-0 w-100 h-100 bg-dark bg-opacity-50 d-lg-none';
+                overlay.style.zIndex = '1025';
+                overlay.style.display = 'none';
+                document.body.appendChild(overlay);
+
+                const closeSidebar = function() {
+                    sidebar.classList.remove('show');
+                    overlay.style.display = 'none';
+                    document.body.classList.remove('overflow-hidden');
+                };
+
+                const openSidebar = function() {
+                    sidebar.classList.add('show');
+                    overlay.style.display = 'block';
+                    document.body.classList.add('overflow-hidden');
+                };
+
+                sidebarToggle.addEventListener('click', function() {
+                    if (sidebar.classList.contains('show')) {
+                        closeSidebar();
+                    } else {
+                        openSidebar();
+                    }
+                });
+
+                overlay.addEventListener('click', closeSidebar);
+
+                sidebar.querySelectorAll('.nav-link').forEach(function(link) {
+                    link.addEventListener('click', function() {
+                        if (window.innerWidth < 992) {
+                            closeSidebar();
+                        }
+                    });
+                });
+            }
+
+            if (window.location.pathname.includes('dashboard.php')) {
+                setInterval(function() {
+                    fetch('ajax/refresh-stats.php')
+                        .then(response => response.json())
+                        .then(data => {
+                            if (data.success) {
+                                Object.keys(data.stats).forEach(key => {
+                                    const element = document.querySelector(`[data-stat="${key}"]`);
+                                    if (element) {
+                                        element.textContent = data.stats[key];
+                                    }
+                                });
+                            }
+                        })
+                        .catch(error => console.log('Stats refresh failed:', error));
+                }, 30000);
             }
         });
-
-        // Auto-refresh dashboard stats every 30 seconds
-        if (window.location.pathname.includes('dashboard.php')) {
-            setInterval(function() {
-                fetch('ajax/refresh-stats.php')
-                    .then(response => response.json())
-                    .then(data => {
-                        if (data.success) {
-                            // Update stats without page reload
-                            Object.keys(data.stats).forEach(key => {
-                                const element = document.querySelector(`[data-stat="${key}"]`);
-                                if (element) {
-                                    element.textContent = data.stats[key];
-                                }
-                            });
-                        }
-                    })
-                    .catch(error => console.log('Stats refresh failed:', error));
-            }, 30000);
-        }
     </script>
 </body>
 </html>

--- a/admin/includes/admin_header.php
+++ b/admin/includes/admin_header.php
@@ -1,163 +1,73 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?php echo $page_title ?? 'Admin Panel - ' . SITE_NAME; ?></title>
-    
-    <!-- Bootstrap 5 CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <!-- Font Awesome -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <!-- Chart.js -->
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Nunito+Sans:wght@400;600;700&display=swap" rel="stylesheet">
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2Lw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="assets/css/theme.css?v=1">
+
+    <script>
+        (function() {
+            const savedTheme = localStorage.getItem('admin-theme');
+            if (savedTheme) {
+                document.documentElement.setAttribute('data-theme', savedTheme);
+            }
+        })();
+    </script>
+
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    
-    <style>
-        body {
-            background-color: #f8f9fc;
-        }
-        
-        .sidebar {
-            position: fixed;
-            top: 0;
-            bottom: 0;
-            left: 0;
-            z-index: 100;
-            padding: 48px 0 0;
-            box-shadow: inset -1px 0 0 rgba(0, 0, 0, .1);
-        }
-        
-        .sidebar-sticky {
-            position: relative;
-            top: 0;
-            height: calc(100vh - 48px);
-            padding-top: .5rem;
-            overflow-x: hidden;
-            overflow-y: auto;
-        }
-        
-        .navbar-brand {
-            padding-top: .75rem;
-            padding-bottom: .75rem;
-            font-size: 1rem;
-            background-color: rgba(0, 0, 0, .25);
-            box-shadow: inset -1px 0 0 rgba(0, 0, 0, .25);
-        }
-        
-        .navbar .navbar-toggler {
-            top: .25rem;
-            right: 1rem;
-        }
-        
-        .navbar .form-control {
-            padding: .75rem 1rem;
-            border-width: 0;
-            border-radius: 0;
-        }
-        
-        .border-left-primary {
-            border-left: 0.25rem solid #4e73df !important;
-        }
-        
-        .border-left-success {
-            border-left: 0.25rem solid #1cc88a !important;
-        }
-        
-        .border-left-info {
-            border-left: 0.25rem solid #36b9cc !important;
-        }
-        
-        .border-left-warning {
-            border-left: 0.25rem solid #f6c23e !important;
-        }
-        
-        .border-left-danger {
-            border-left: 0.25rem solid #e74a3b !important;
-        }
-        
-        .text-gray-300 {
-            color: #dddfeb !important;
-        }
-        
-        .text-gray-800 {
-            color: #5a5c69 !important;
-        }
-        
-        .shadow {
-            box-shadow: 0 0.15rem 1.75rem 0 rgba(58, 59, 69, 0.15) !important;
-        }
-        
-        .card {
-            border: none;
-        }
-        
-        .nav-link {
-            color: #858796;
-        }
-        
-        .nav-link:hover {
-            color: #5a5c69;
-        }
-        
-        .nav-link.active {
-            color: #4e73df;
-            font-weight: 700;
-        }
-        
-        .btn-block {
-            width: 100%;
-        }
-        
-        .table th {
-            border-top: none;
-            font-weight: 600;
-            color: #5a5c69;
-        }
-        
-        .badge {
-            font-size: 0.75em;
-        }
-        
-        .alert {
-            border: none;
-            border-radius: 0.35rem;
-        }
-        
-        .form-control:focus {
-            border-color: #4e73df;
-            box-shadow: 0 0 0 0.2rem rgba(78, 115, 223, 0.25);
-        }
-        
-        .btn-primary {
-            background-color: #4e73df;
-            border-color: #4e73df;
-        }
-        
-        .btn-primary:hover {
-            background-color: #2e59d9;
-            border-color: #2653d4;
-        }
-        
-        .text-primary {
-            color: #4e73df !important;
-        }
-        
-        .bg-primary {
-            background-color: #4e73df !important;
-        }
-    </style>
 </head>
-<body>
-    <nav class="navbar navbar-dark sticky-top bg-dark flex-md-nowrap p-0 shadow">
-        <a class="navbar-brand col-md-3 col-lg-2 me-0 px-3" href="dashboard.php">
-            <?php echo SITE_NAME; ?> Admin
-        </a>
-        <button class="navbar-toggler position-absolute d-md-none collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#sidebarMenu">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="navbar-nav">
-            <div class="nav-item text-nowrap">
-                <a class="nav-link px-3" href="../logout.php">Sign out</a>
+<body class="admin-app">
+    <nav class="navbar navbar-expand-lg admin-navbar">
+        <div class="container-fluid">
+            <div class="d-flex align-items-center gap-2">
+                <button class="btn btn-link text-white p-0 fs-4 d-lg-none" id="sidebarToggle" aria-label="Toggle navigation">
+                    <i class="fas fa-bars"></i>
+                </button>
+                <a class="navbar-brand" href="dashboard.php">
+                    <span class="brand-initial">GM</span>
+                    <span><?php echo SITE_NAME; ?> God Mode</span>
+                </a>
+            </div>
+
+            <div class="d-flex align-items-center gap-3 ms-auto">
+                <form class="d-none d-md-flex" action="sites.php" method="get" role="search">
+                    <div class="input-group">
+                        <span class="input-group-text bg-transparent border-0 text-white-50"><i class="fas fa-search"></i></span>
+                        <input type="text" class="form-control" placeholder="Quick search..." name="search" value="<?php echo htmlspecialchars($_GET['search'] ?? ''); ?>">
+                    </div>
+                </form>
+
+                <button class="theme-toggle" type="button" id="themeToggle" aria-label="Toggle theme">
+                    <i class="fas fa-moon"></i>
+                </button>
+
+                <div class="dropdown">
+                    <a class="d-flex align-items-center text-white text-decoration-none dropdown-toggle" href="#" role="button" id="userDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+                        <div class="me-2 text-end d-none d-sm-block">
+                            <small class="d-block text-white-50">Administrator</small>
+                            <span class="fw-semibold"><?php echo htmlspecialchars($_SESSION['username'] ?? 'Admin'); ?></span>
+                        </div>
+                        <span class="avatar bg-white bg-opacity-25 rounded-circle d-inline-flex justify-content-center align-items-center" style="width: 40px; height: 40px;">
+                            <i class="fas fa-user-shield"></i>
+                        </span>
+                    </a>
+                    <ul class="dropdown-menu dropdown-menu-end shadow">
+                        <li><h6 class="dropdown-header">Signed in as <strong><?php echo htmlspecialchars($_SESSION['username'] ?? 'Admin'); ?></strong></h6></li>
+                        <li><a class="dropdown-item" href="../profile.php"><i class="fas fa-id-badge me-2 text-primary"></i>Profile</a></li>
+                        <li><a class="dropdown-item" href="settings.php"><i class="fas fa-sliders me-2 text-primary"></i>Settings</a></li>
+                        <li><hr class="dropdown-divider"></li>
+                        <li><a class="dropdown-item text-danger" href="../logout.php"><i class="fas fa-sign-out-alt me-2"></i>Sign out</a></li>
+                    </ul>
+                </div>
             </div>
         </div>
     </nav>
+    <div class="admin-layout">

--- a/admin/includes/admin_sidebar.php
+++ b/admin/includes/admin_sidebar.php
@@ -1,133 +1,124 @@
-<nav id="sidebarMenu" class="col-md-3 col-lg-2 d-md-block bg-light sidebar collapse">
-    <div class="position-sticky pt-3">
-        <ul class="nav flex-column">
-            <li class="nav-item">
+<aside id="sidebarMenu" class="admin-sidebar">
+    <div class="d-flex flex-column h-100">
+        <div>
+            <p class="sidebar-title text-uppercase">Main Navigation</p>
+            <nav class="nav flex-column nav-section">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'dashboard.php' ? 'active' : ''; ?>" href="dashboard.php">
-                    <i class="fas fa-gauge-high"></i> Dashboard
+                    <span class="icon-wrapper"><i class="fas fa-gauge-high"></i></span>
+                    <span>Dashboard</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'sites.php' ? 'active' : ''; ?>" href="sites.php">
-                    <i class="fas fa-globe"></i> Sites Management
+                    <span class="icon-wrapper"><i class="fas fa-globe"></i></span>
+                    <span>Sites Management</span>
+                    <?php if (!empty($stats['pending_sites'] ?? null)): ?>
+                        <span class="badge ms-auto">Pending</span>
+                    <?php endif; ?>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'backlink-tracking.php' ? 'active' : ''; ?>" href="backlink-tracking.php">
-                    <i class="fas fa-link"></i> Backlink Tracking
+                    <span class="icon-wrapper"><i class="fas fa-link"></i></span>
+                    <span>Backlink Tracking</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'users.php' ? 'active' : ''; ?>" href="users.php">
-                    <i class="fas fa-users"></i> Users Management
+                    <span class="icon-wrapper"><i class="fas fa-users"></i></span>
+                    <span>Users Management</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'create-user.php' ? 'active' : ''; ?>" href="create-user.php">
-                    <i class="fas fa-user-plus"></i> Create User
+                    <span class="icon-wrapper"><i class="fas fa-user-plus"></i></span>
+                    <span>Create User</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'reviews.php' ? 'active' : ''; ?>" href="reviews.php">
-                    <i class="fas fa-comments"></i> Reviews Management
+                    <span class="icon-wrapper"><i class="fas fa-comments"></i></span>
+                    <span>Reviews</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'categories.php' ? 'active' : ''; ?>" href="categories.php">
-                    <i class="fas fa-tags"></i> Categories
+                    <span class="icon-wrapper"><i class="fas fa-tags"></i></span>
+                    <span>Categories</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'notifications.php' ? 'active' : ''; ?>" href="notifications.php">
-                    <i class="fas fa-bell"></i> Notifications
+                    <span class="icon-wrapper"><i class="fas fa-bell"></i></span>
+                    <span>Notifications</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'email.php' ? 'active' : ''; ?>" href="email.php">
-                    <i class="fas fa-envelope"></i> Email Campaigns
+                    <span class="icon-wrapper"><i class="fas fa-envelope"></i></span>
+                    <span>Email Campaigns</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'newsletter.php' ? 'active' : ''; ?>" href="newsletter.php">
-                    <i class="fas fa-newspaper"></i> Newsletter
+                    <span class="icon-wrapper"><i class="fas fa-newspaper"></i></span>
+                    <span>Newsletter</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'support.php' ? 'active' : ''; ?>" href="support.php">
-                    <i class="fas fa-headset"></i> Support Tickets
+                    <span class="icon-wrapper"><i class="fas fa-headset"></i></span>
+                    <span>Support Tickets</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'badges.php' ? 'active' : ''; ?>" href="badges.php">
-                    <i class="fas fa-medal"></i> Badge System
+                    <span class="icon-wrapper"><i class="fas fa-medal"></i></span>
+                    <span>Badges</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'wallet.php' ? 'active' : ''; ?>" href="wallet.php">
-                    <i class="fas fa-wallet"></i> Wallet System
+                    <span class="icon-wrapper"><i class="fas fa-wallet"></i></span>
+                    <span>Wallet System</span>
                 </a>
-            </li>
-             Updated ad management link to new revenue system 
-            <li class="nav-item">
-                <a class="nav-link <?php echo in_array(basename($_SERVER['PHP_SELF']), ['ads.php', 'ad-revenue.php', 'ad-analytics.php']) ? 'active' : ''; ?>" href="ad-revenue.php">
-                    <i class="fas fa-ad"></i> Ad Revenue System
+                <a class="nav-link <?php echo in_array(basename($_SERVER['PHP_SELF']), ['ads.php', 'ad-revenue.php', 'ad-analytics.php', 'manage-ad-spaces.php', 'ad-control.php']) ? 'active' : ''; ?>" href="ad-revenue.php">
+                    <span class="icon-wrapper"><i class="fas fa-ad"></i></span>
+                    <span>Ad Revenue Suite</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'promotions.php' ? 'active' : ''; ?>" href="promotions.php">
-                    <i class="fas fa-rocket"></i> Promotions
+                    <span class="icon-wrapper"><i class="fas fa-rocket"></i></span>
+                    <span>Promotions</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'coupons.php' ? 'active' : ''; ?>" href="coupons.php">
-                    <i class="fas fa-ticket-simple"></i> Coupon System
+                    <span class="icon-wrapper"><i class="fas fa-ticket"></i></span>
+                    <span>Coupons</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'analytics.php' ? 'active' : ''; ?>" href="analytics.php">
-                    <i class="fas fa-chart-line"></i> Analytics
+                    <span class="icon-wrapper"><i class="fas fa-chart-line"></i></span>
+                    <span>Analytics</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'site-statistics.php' ? 'active' : ''; ?>" href="site-statistics.php">
-                    <i class="fas fa-chart-bar"></i> Site Statistics
+                    <span class="icon-wrapper"><i class="fas fa-chart-bar"></i></span>
+                    <span>Site Statistics</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'dead-links.php' ? 'active' : ''; ?>" href="dead-links.php">
-                    <i class="fas fa-unlink"></i> Dead Links
+                    <span class="icon-wrapper"><i class="fas fa-unlink"></i></span>
+                    <span>Dead Links</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'security.php' ? 'active' : ''; ?>" href="security.php">
-                    <i class="fas fa-shield-halved"></i> Security
+                    <span class="icon-wrapper"><i class="fas fa-shield-halved"></i></span>
+                    <span>Security</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'settings.php' ? 'active' : ''; ?>" href="settings.php">
-                    <i class="fas fa-cog"></i> Settings
+                    <span class="icon-wrapper"><i class="fas fa-sliders-h"></i></span>
+                    <span>Settings</span>
                 </a>
-            </li>
-        </ul>
+            </nav>
+        </div>
 
-        <h6 class="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1 text-muted">
-            <span>Tools</span>
-        </h6>
-        <ul class="nav flex-column mb-2">
-            <li class="nav-item">
+        <div>
+            <p class="sidebar-title text-uppercase">Tools &amp; Logs</p>
+            <nav class="nav flex-column nav-section">
                 <a class="nav-link" href="backup.php">
-                    <i class="fas fa-database"></i> Database Backup
+                    <span class="icon-wrapper"><i class="fas fa-database"></i></span>
+                    <span>Database Backup</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link" href="logs.php">
-                    <i class="fas fa-file-lines"></i> System Logs
+                    <span class="icon-wrapper"><i class="fas fa-file-lines"></i></span>
+                    <span>System Logs</span>
                 </a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link" href="../index.php" target="_blank">
-                    <i class="fas fa-arrow-up-right-from-square"></i> View Site
+                    <span class="icon-wrapper"><i class="fas fa-arrow-up-right-from-square"></i></span>
+                    <span>View Site</span>
                 </a>
-            </li>
-        </ul>
+            </nav>
+        </div>
+
+        <div class="sidebar-footer mt-4">
+            <div class="d-flex align-items-center justify-content-between">
+                <div>
+                    <span class="d-block fw-semibold">Status</span>
+                    <small class="text-muted">System operational</small>
+                </div>
+                <span class="badge">v<?php echo defined('APP_VERSION') ? APP_VERSION : '1.0'; ?></span>
+            </div>
+        </div>
     </div>
-</nav>
+</aside>

--- a/admin/reviews.php
+++ b/admin/reviews.php
@@ -131,14 +131,20 @@ $page_title = 'Reviews Management - Admin Panel';
 include 'includes/admin_header.php';
 ?>
 
-<div class="container-fluid">
-    <div class="row">
-        <?php include 'includes/admin_sidebar.php'; ?>
-        
-        <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
-            <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-                <h1 class="h2">Reviews Management</h1>
+<?php include 'includes/admin_sidebar.php'; ?>
+
+<main class="admin-main">
+    <div class="admin-page-header">
+        <div>
+            <div class="admin-breadcrumb">
+                <i class="fas fa-comments text-primary"></i>
+                <span>Community</span>
+                <span class="text-muted">Reviews</span>
             </div>
+            <h1>Feedback Radar</h1>
+            <p class="text-muted mb-0">Moderate trust signals and surface standout experiences.</p>
+        </div>
+    </div>
 
             <?php if ($success_message): ?>
                 <div class="alert alert-success"><?php echo htmlspecialchars($success_message); ?></div>
@@ -148,10 +154,9 @@ include 'includes/admin_header.php';
                 <div class="alert alert-danger"><?php echo htmlspecialchars($error_message); ?></div>
             <?php endif; ?>
 
-            <!-- Filters -->
-            <div class="card mb-4">
-                <div class="card-body">
-                    <form method="GET" class="row g-3">
+    <!-- Filters -->
+    <div class="admin-content-wrapper mb-4">
+        <form method="GET" class="row g-3">
                         <div class="col-md-4">
                             <label class="form-label">Search Reviews</label>
                             <input type="text" name="search" class="form-control" 
@@ -172,13 +177,11 @@ include 'includes/admin_header.php';
                             <label class="form-label">&nbsp;</label>
                             <button type="submit" class="btn btn-primary d-block">Filter</button>
                         </div>
-                    </form>
-                </div>
-            </div>
+        </form>
+    </div>
 
-            <!-- Reviews List -->
-            <div class="card">
-                <div class="card-body">
+    <!-- Reviews List -->
+    <div class="admin-content-wrapper">
                     <?php if (!empty($reviews)): ?>
                         <?php foreach ($reviews as $review): ?>
                         <div class="border-bottom pb-3 mb-3">
@@ -307,8 +310,6 @@ include 'includes/admin_header.php';
                     <?php endif; ?>
                 </div>
             </div>
-        </main>
-    </div>
-</div>
+</main>
 
 <?php include 'includes/admin_footer.php'; ?>

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -105,14 +105,20 @@ $page_title = 'Settings - Admin Panel';
 include 'includes/admin_header.php';
 ?>
 
-<div class="container-fluid">
-    <div class="row">
-        <?php include 'includes/admin_sidebar.php'; ?>
-        
-        <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
-            <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-                <h1 class="h2">Settings</h1>
+<?php include 'includes/admin_sidebar.php'; ?>
+
+<main class="admin-main">
+    <div class="admin-page-header">
+        <div>
+            <div class="admin-breadcrumb">
+                <i class="fas fa-sliders-h text-primary"></i>
+                <span>System</span>
+                <span class="text-muted">Settings</span>
             </div>
+            <h1>Control Center</h1>
+            <p class="text-muted mb-0">Configure payouts, redirects, and security guardrails.</p>
+        </div>
+    </div>
 
             <?php if ($success_message): ?>
                 <div class="alert alert-success"><?php echo htmlspecialchars($success_message); ?></div>
@@ -149,7 +155,7 @@ include 'includes/admin_header.php';
             <div class="tab-content" id="settingsTabContent">
                 <!-- Wallet Settings -->
                 <div class="tab-pane fade show active" id="wallet" role="tabpanel">
-                    <div class="card mt-3">
+                    <div class="card admin-content-wrapper mt-3">
                         <div class="card-body">
                             <form method="POST">
                                 <input type="hidden" name="tab" value="wallet">
@@ -235,7 +241,7 @@ include 'includes/admin_header.php';
 
                 <!-- Redirect Settings -->
                 <div class="tab-pane fade" id="redirect" role="tabpanel">
-                    <div class="card mt-3">
+                    <div class="card admin-content-wrapper mt-3">
                         <div class="card-body">
                             <form method="POST">
                                 <input type="hidden" name="tab" value="redirect">
@@ -269,7 +275,7 @@ include 'includes/admin_header.php';
 
                 <!-- Upload Settings -->
                 <div class="tab-pane fade" id="upload" role="tabpanel">
-                    <div class="card mt-3">
+                    <div class="card admin-content-wrapper mt-3">
                         <div class="card-body">
                             <form method="POST">
                                 <input type="hidden" name="tab" value="upload">
@@ -311,7 +317,7 @@ include 'includes/admin_header.php';
 
                 <!-- General Settings -->
                 <div class="tab-pane fade" id="general" role="tabpanel">
-                    <div class="card mt-3">
+                    <div class="card admin-content-wrapper mt-3">
                         <div class="card-body">
                             <h5>Site Information</h5>
                             <div class="row">
@@ -334,9 +340,7 @@ include 'includes/admin_header.php';
                     </div>
                 </div>
             </div>
-        </main>
-    </div>
-</div>
+</main>
 
 <!-- Edit Currency Modal -->
 <div class="modal fade" id="editCurrencyModal" tabindex="-1">

--- a/admin/sites.php
+++ b/admin/sites.php
@@ -537,17 +537,23 @@ if ($approval_filter !== 'all') {
 include 'includes/admin_header.php';
 ?>
 
-<div class="container-fluid">
-    <div class="row">
-        <?php include 'includes/admin_sidebar.php'; ?>
-        
-        <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
-            <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-                <h1 class="h2">Sites Management</h1>
-                <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addSiteModal">
-                    <i class="fas fa-plus"></i> Add New Site
-                </button>
+<?php include 'includes/admin_sidebar.php'; ?>
+
+<main class="admin-main">
+    <div class="admin-page-header">
+        <div>
+            <div class="admin-breadcrumb">
+                <i class="fas fa-globe text-primary"></i>
+                <span>Content</span>
+                <span class="text-muted">Sites</span>
             </div>
+            <h1>Sites Management</h1>
+            <p class="text-muted mb-0">Approve, elevate, and moderate listings across the network.</p>
+        </div>
+        <button class="btn btn-primary shadow-hover" data-bs-toggle="modal" data-bs-target="#addSiteModal">
+            <i class="fas fa-plus"></i> Add New Site
+        </button>
+    </div>
 
             <?php if ($success_message): ?>
                 <div class="alert alert-success"><?php echo htmlspecialchars($success_message); ?></div>
@@ -557,10 +563,9 @@ include 'includes/admin_header.php';
                 <div class="alert alert-danger"><?php echo htmlspecialchars($error_message); ?></div>
             <?php endif; ?>
 
-            <!-- Filters -->
-            <div class="card mb-4">
-                <div class="card-body">
-                    <form method="GET" class="row g-3">
+    <!-- Filters -->
+    <div class="admin-content-wrapper mb-4">
+        <form method="GET" class="row g-3">
                         <div class="col-md-3">
                             <label class="form-label">Status</label>
                             <select name="status" class="form-select">
@@ -596,13 +601,11 @@ include 'includes/admin_header.php';
                             <label class="form-label">&nbsp;</label>
                             <button type="submit" class="btn btn-primary d-block">Filter</button>
                         </div>
-                    </form>
-                </div>
-            </div>
+        </form>
+    </div>
 
-            <!-- Sites Table -->
-            <div class="card">
-                <div class="card-body">
+    <!-- Sites Table -->
+    <div class="admin-content-wrapper">
                     <div class="table-responsive">
                         <table class="table table-striped">
                             <thead>
@@ -745,9 +748,7 @@ include 'includes/admin_header.php';
                     <?php endif; ?>
                 </div>
             </div>
-        </main>
-    </div>
-</div>
+</main>
 
 <!-- Site Details Modal -->
 <div class="modal fade" id="siteDetailsModal" tabindex="-1">

--- a/admin/support.php
+++ b/admin/support.php
@@ -142,14 +142,20 @@ $page_title = 'Support Tickets - Admin Panel';
 include 'includes/admin_header.php';
 ?>
 
-<div class="container-fluid">
-    <div class="row">
-        <?php include 'includes/admin_sidebar.php'; ?>
-        
-        <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
-            <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-                <h1 class="h2">Support Tickets</h1>
+<?php include 'includes/admin_sidebar.php'; ?>
+
+<main class="admin-main">
+    <div class="admin-page-header">
+        <div>
+            <div class="admin-breadcrumb">
+                <i class="fas fa-life-ring text-primary"></i>
+                <span>Operations</span>
+                <span class="text-muted">Support</span>
             </div>
+            <h1>Support Mission Desk</h1>
+            <p class="text-muted mb-0">Track escalations, assign responders, and delight the community.</p>
+        </div>
+    </div>
 
             <?php if ($success_message): ?>
                 <div class="alert alert-success"><?php echo htmlspecialchars($success_message); ?></div>
@@ -159,77 +165,61 @@ include 'includes/admin_header.php';
                 <div class="alert alert-danger"><?php echo htmlspecialchars($error_message); ?></div>
             <?php endif; ?>
 
-            <!-- Ticket Statistics -->
-            <div class="row mb-4">
-                <div class="col-xl-3 col-md-6 mb-4">
-                    <div class="card border-left-primary shadow h-100 py-2">
-                        <div class="card-body">
-                            <div class="row no-gutters align-items-center">
-                                <div class="col mr-2">
-                                    <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Total Tickets</div>
-                                    <div class="h5 mb-0 font-weight-bold text-gray-800"><?php echo number_format($ticket_stats['total_tickets']); ?></div>
-                                </div>
-                                <div class="col-auto">
-                                    <i class="fas fa-ticket-simple fa-2x text-gray-300"></i>
-                                </div>
-                            </div>
-                        </div>
+    <!-- Ticket Statistics -->
+    <div class="row g-4 mb-4">
+        <div class="col-xl-3 col-md-6">
+            <div class="admin-metric-card h-100">
+                <div class="d-flex justify-content-between align-items-start">
+                    <div>
+                        <p class="metric-label">Total Tickets</p>
+                        <p class="metric-value mb-1"><?php echo number_format($ticket_stats['total_tickets']); ?></p>
+                        <span class="metric-trend up"><i class="fas fa-life-ring"></i>Queue volume</span>
                     </div>
-                </div>
-
-                <div class="col-xl-3 col-md-6 mb-4">
-                    <div class="card border-left-warning shadow h-100 py-2">
-                        <div class="card-body">
-                            <div class="row no-gutters align-items-center">
-                                <div class="col mr-2">
-                                    <div class="text-xs font-weight-bold text-warning text-uppercase mb-1">Open Tickets</div>
-                                    <div class="h5 mb-0 font-weight-bold text-gray-800"><?php echo number_format($ticket_stats['open_tickets']); ?></div>
-                                </div>
-                                <div class="col-auto">
-                                    <i class="fas fa-exclamation-circle fa-2x text-gray-300"></i>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="col-xl-3 col-md-6 mb-4">
-                    <div class="card border-left-success shadow h-100 py-2">
-                        <div class="card-body">
-                            <div class="row no-gutters align-items-center">
-                                <div class="col mr-2">
-                                    <div class="text-xs font-weight-bold text-success text-uppercase mb-1">Replied Tickets</div>
-                                    <div class="h5 mb-0 font-weight-bold text-gray-800"><?php echo number_format($ticket_stats['replied_tickets']); ?></div>
-                                </div>
-                                <div class="col-auto">
-                                    <i class="fas fa-reply fa-2x text-gray-300"></i>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="col-xl-3 col-md-6 mb-4">
-                    <div class="card border-left-danger shadow h-100 py-2">
-                        <div class="card-body">
-                            <div class="row no-gutters align-items-center">
-                                <div class="col mr-2">
-                                    <div class="text-xs font-weight-bold text-danger text-uppercase mb-1">High Priority</div>
-                                    <div class="h5 mb-0 font-weight-bold text-gray-800"><?php echo number_format($ticket_stats['high_priority']); ?></div>
-                                </div>
-                                <div class="col-auto">
-                                    <i class="fas fa-fire fa-2x text-gray-300"></i>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <span class="icon-wrapper"><i class="fas fa-ticket-simple"></i></span>
                 </div>
             </div>
+        </div>
+        <div class="col-xl-3 col-md-6">
+            <div class="admin-metric-card h-100">
+                <div class="d-flex justify-content-between align-items-start">
+                    <div>
+                        <p class="metric-label">Open Tickets</p>
+                        <p class="metric-value mb-1"><?php echo number_format($ticket_stats['open_tickets']); ?></p>
+                        <span class="metric-trend <?php echo $ticket_stats['open_tickets'] > 0 ? 'down' : 'up'; ?>"><i class="fas fa-inbox"></i><?php echo $ticket_stats['open_tickets'] > 0 ? 'Needs attention' : 'All clear'; ?></span>
+                    </div>
+                    <span class="icon-wrapper"><i class="fas fa-envelope-open-text"></i></span>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6">
+            <div class="admin-metric-card h-100">
+                <div class="d-flex justify-content-between align-items-start">
+                    <div>
+                        <p class="metric-label">Replied Tickets</p>
+                        <p class="metric-value mb-1"><?php echo number_format($ticket_stats['replied_tickets']); ?></p>
+                        <span class="metric-trend up"><i class="fas fa-reply"></i>Rapid responses</span>
+                    </div>
+                    <span class="icon-wrapper"><i class="fas fa-comments"></i></span>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6">
+            <div class="admin-metric-card h-100">
+                <div class="d-flex justify-content-between align-items-start">
+                    <div>
+                        <p class="metric-label">High Priority</p>
+                        <p class="metric-value mb-1"><?php echo number_format($ticket_stats['high_priority']); ?></p>
+                        <span class="metric-trend <?php echo $ticket_stats['high_priority'] > 0 ? 'down' : 'up'; ?>"><i class="fas fa-fire"></i><?php echo $ticket_stats['high_priority'] > 0 ? 'Escalations pending' : 'No fires'; ?></span>
+                    </div>
+                    <span class="icon-wrapper"><i class="fas fa-bolt"></i></span>
+                </div>
+            </div>
+        </div>
+    </div>
 
-            <!-- Filters -->
-            <div class="card mb-4">
-                <div class="card-body">
-                    <form method="GET" class="row g-3">
+    <!-- Filters -->
+    <div class="admin-content-wrapper mb-4">
+        <form method="GET" class="row g-3">
                         <div class="col-md-4">
                             <label class="form-label">Status</label>
                             <select name="status" class="form-select">
@@ -252,13 +242,11 @@ include 'includes/admin_header.php';
                             <label class="form-label">&nbsp;</label>
                             <button type="submit" class="btn btn-primary d-block">Filter</button>
                         </div>
-                    </form>
-                </div>
-            </div>
+        </form>
+    </div>
 
-            <!-- Tickets List -->
-            <div class="card shadow mb-4">
-                <div class="card-body">
+    <!-- Tickets List -->
+    <div class="admin-content-wrapper">
                     <?php if (!empty($tickets)): ?>
                         <?php foreach ($tickets as $ticket): ?>
                         <div class="border-bottom pb-3 mb-3">
@@ -326,11 +314,8 @@ include 'includes/admin_header.php';
                             <p class="text-muted">No tickets match your current filters.</p>
                         </div>
                     <?php endif; ?>
-                </div>
-            </div>
-        </main>
     </div>
-</div>
+</main>
 
 <!-- Reply Modal -->
 <div class="modal fade" id="replyModal" tabindex="-1">

--- a/admin/users.php
+++ b/admin/users.php
@@ -322,14 +322,20 @@ $page_title = 'Users Management - Admin Panel';
 include 'includes/admin_header.php';
 ?>
 
-<div class="container-fluid">
-    <div class="row">
-        <?php include 'includes/admin_sidebar.php'; ?>
-        
-        <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
-            <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-                <h1 class="h2">Users Management</h1>
+<?php include 'includes/admin_sidebar.php'; ?>
+
+<main class="admin-main">
+    <div class="admin-page-header">
+        <div>
+            <div class="admin-breadcrumb">
+                <i class="fas fa-users text-primary"></i>
+                <span>Community</span>
+                <span class="text-muted">Users</span>
             </div>
+            <h1>User Intelligence</h1>
+            <p class="text-muted mb-0">Ban, promote, and analyze every account in the ecosystem.</p>
+        </div>
+    </div>
 
             <?php if ($success_message): ?>
                 <div class="alert alert-success"><?php echo htmlspecialchars($success_message); ?></div>
@@ -339,10 +345,9 @@ include 'includes/admin_header.php';
                 <div class="alert alert-danger"><?php echo htmlspecialchars($error_message); ?></div>
             <?php endif; ?>
 
-            <!-- Filters -->
-            <div class="card mb-4">
-                <div class="card-body">
-                    <form method="GET" class="row g-3">
+    <!-- Filters -->
+    <div class="admin-content-wrapper mb-4">
+        <form method="GET" class="row g-3">
                         <div class="col-md-4">
                             <label class="form-label">Search Users</label>
                             <input type="text" name="search" class="form-control" 
@@ -362,13 +367,11 @@ include 'includes/admin_header.php';
                             <label class="form-label">&nbsp;</label>
                             <button type="submit" class="btn btn-primary d-block">Filter</button>
                         </div>
-                    </form>
-                </div>
-            </div>
+        </form>
+    </div>
 
-            <!-- Users Table -->
-            <div class="card">
-                <div class="card-body">
+    <!-- Users Table -->
+    <div class="admin-content-wrapper">
                     <div class="table-responsive">
                         <table class="table table-striped">
                             <thead>
@@ -508,9 +511,7 @@ include 'includes/admin_header.php';
                     <?php endif; ?>
                 </div>
             </div>
-        </main>
-    </div>
-</div>
+</main>
 
 <!-- Ban User Modal -->
 <div class="modal fade" id="banUserModal" tabindex="-1">


### PR DESCRIPTION
## Summary
- add an AdminLTE-inspired theme stylesheet and global header/sidebar/footer shell with theme toggle, quick search, and mobile overlay support
- refresh the dashboard, analytics, and support screens with metric cards, responsive wrappers, and updated summaries
- update sites, users, reviews, ads, and settings management pages to slot into the new layout structure

## Testing
- php -l admin/dashboard.php admin/sites.php admin/users.php admin/reviews.php admin/ads.php admin/support.php admin/settings.php admin/analytics.php admin/includes/admin_header.php admin/includes/admin_footer.php admin/includes/admin_sidebar.php

------
https://chatgpt.com/codex/tasks/task_e_68e44ac0e87083299f228167f7e63693