### PR TITLE
Fix badge onboarding and repair forgot password captcha

### DIFF
--- a/ajax/newsletter-subscribe.php
+++ b/ajax/newsletter-subscribe.php
@@ -1,6 +1,8 @@
 <?php
 require_once __DIR__ . '/../config/config.php';
 require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/../includes/MailService.php';
+require_once __DIR__ . '/../includes/newsletter_helpers.php';
 
 header('Content-Type: application/json');
 header('Access-Control-Allow-Origin: *');
@@ -30,40 +32,51 @@ try {
     $database = new Database();
     $db = $database->getConnection();
     
+    $mailer = MailService::getInstance();
+
     // Check if already subscribed
     $check_query = "SELECT id, is_active FROM newsletter_subscriptions WHERE email = :email";
     $check_stmt = $db->prepare($check_query);
     $check_stmt->bindParam(':email', $email);
     $check_stmt->execute();
     $existing = $check_stmt->fetch(PDO::FETCH_ASSOC);
-    
+
     if ($existing) {
-        if ($existing['is_active']) {
-            echo json_encode(['success' => false, 'message' => 'This email is already subscribed']);
-        } else {
-            // Reactivate subscription
-            $reactivate_query = "UPDATE newsletter_subscriptions SET is_active = 1, updated_at = NOW() WHERE email = :email";
-            $reactivate_stmt = $db->prepare($reactivate_query);
-            $reactivate_stmt->bindParam(':email', $email);
-            $reactivate_stmt->execute();
-            
-            echo json_encode(['success' => true, 'message' => 'Subscription reactivated successfully!']);
+        if ((int) $existing['is_active'] === 1) {
+            echo json_encode(['success' => false, 'message' => 'This email is already subscribed and active.']);
+            exit();
         }
+
+        $token = newsletter_generate_verification_token();
+        $reactivate_query = "UPDATE newsletter_subscriptions SET verification_token = :token, verified_at = NULL, is_active = 0, updated_at = NOW() WHERE id = :id";
+        $reactivate_stmt = $db->prepare($reactivate_query);
+        $reactivate_stmt->execute([
+            ':token' => $token,
+            ':id' => (int) $existing['id'],
+        ]);
+
+        newsletter_send_confirmation_email($mailer, $email, $token);
+
+        echo json_encode(['success' => true, 'message' => 'Check your inbox to confirm your subscription.']);
         exit();
     }
-    
+
     // Default preferences for footer subscription
     $default_preferences = ['scam_alerts', 'new_sites', 'weekly_digest'];
-    
+
     // Insert new subscription
-    $insert_query = "INSERT INTO newsletter_subscriptions (email, preferences, verified_at) 
-                    VALUES (:email, :preferences, NOW())";
+    $token = newsletter_generate_verification_token();
+    $insert_query = "INSERT INTO newsletter_subscriptions (email, preferences, verification_token, is_active)
+                    VALUES (:email, :preferences, :token, 0)";
     $insert_stmt = $db->prepare($insert_query);
     $insert_stmt->bindParam(':email', $email);
     $insert_stmt->bindParam(':preferences', json_encode($default_preferences));
-    
+    $insert_stmt->bindParam(':token', $token);
+
     if ($insert_stmt->execute()) {
-        echo json_encode(['success' => true, 'message' => 'Successfully subscribed to newsletter!']);
+        newsletter_send_confirmation_email($mailer, $email, $token);
+
+        echo json_encode(['success' => true, 'message' => 'Almost done! Please confirm your email address via the message we just sent.']);
     } else {
         echo json_encode(['success' => false, 'message' => 'Error subscribing to newsletter']);
     }

--- a/includes/email_template.php
+++ b/includes/email_template.php
@@ -1,0 +1,170 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+
+/**
+ * Provide the standard context values shared across email templates.
+ */
+function email_build_context(array $overrides = []): array
+{
+    $defaults = [
+        'site_name' => SITE_NAME,
+        'site_url' => SITE_URL,
+        'support_email' => SITE_EMAIL,
+        'preheader' => '',
+        'subject' => '',
+        'name' => 'there',
+        'username' => 'there',
+        'unsubscribe_url' => '',
+    ];
+
+    return array_merge($defaults, $overrides);
+}
+
+/**
+ * Return the default HTML fragment used inside the email layout.
+ */
+function email_default_content_html(): string
+{
+    return <<<HTML
+<h2 style="margin-top:0;margin-bottom:16px;font-size:22px;line-height:1.3;font-weight:600;color:#111827;">Latest update from {{site_name}}</h2>
+<p style="margin:0 0 16px;color:#374151;font-size:15px;line-height:1.6;">Hi {{name}},</p>
+<p style="margin:0 0 16px;color:#374151;font-size:15px;line-height:1.6;">We wanted to share some fresh news with you. Replace this text with your announcement and feel free to use <strong>bold</strong>, <em>emphasis</em>, links and other formatting tools.</p>
+<ul style="margin:0 0 16px 20px;padding:0;color:#374151;font-size:15px;line-height:1.6;">
+    <li>Use {{name}} or {{username}} to personalise copy.</li>
+    <li>Insert call-to-action buttons and rich formatting.</li>
+    <li>Remember to include clear benefits and next steps.</li>
+</ul>
+<p style="margin:0 0 16px;color:#374151;font-size:15px;line-height:1.6;">Cheers,<br>{{site_name}} Team</p>
+HTML;
+}
+
+/**
+ * Return the default plain text template.
+ */
+function email_default_content_text(): string
+{
+    return <<<TEXT
+Hi {{name}},
+
+Your update goes here. Replace this text with the plain text copy of your announcement. Keep sentences short and scannable. Use {{site_name}} to mention the brand and {{unsubscribe_url}} to reference the unsubscribe link if needed.
+
+Cheers,
+{{site_name}} Team
+TEXT;
+}
+
+/**
+ * Build the final HTML email body using the provided content fragment.
+ *
+ * @param string $contentHtml HTML fragment created by the editor.
+ * @param string $preheader   Preheader text to embed as hidden preview copy.
+ * @param array  $context     Merge tags available to templates.
+ */
+function email_wrap_html(string $contentHtml, string $preheader, array $context): string
+{
+    $content = email_merge_tags($contentHtml, $context, true);
+    $preheaderText = htmlspecialchars($preheader !== '' ? $preheader : ($context['preheader'] ?? ''), ENT_QUOTES, 'UTF-8');
+    $siteName = htmlspecialchars($context['site_name'] ?? SITE_NAME, ENT_QUOTES, 'UTF-8');
+    $unsubscribeUrl = isset($context['unsubscribe_url']) && $context['unsubscribe_url'] !== ''
+        ? htmlspecialchars($context['unsubscribe_url'], ENT_QUOTES, 'UTF-8')
+        : '';
+
+    $unsubscribeBlock = $unsubscribeUrl !== ''
+        ? '<p style="margin:0;font-size:12px;color:#6b7280;">No longer wish to hear from us? <a href="' . $unsubscribeUrl . '" style="color:#6b7280;text-decoration:underline;">Unsubscribe instantly</a>.</p>'
+        : '';
+
+    $year = date('Y');
+
+    return <<<HTML
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light dark">
+    <meta name="supported-color-schemes" content="light dark">
+    <title>{$siteName}</title>
+    <style>
+        @media (prefers-color-scheme: dark) {
+            body, table, td { background-color: #0f172a !important; color: #e2e8f0 !important; }
+            a { color: #38bdf8 !important; }
+        }
+    </style>
+</head>
+<body style="margin:0;padding:0;background-color:#f5f7fa;font-family:Segoe UI,Helvetica,Arial,sans-serif;">
+    <span style="display:none !important;visibility:hidden;mso-hide:all;font-size:1px;color:#f5f7fa;line-height:1px;max-height:0;max-width:0;opacity:0;overflow:hidden;">{$preheaderText}</span>
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background-color:#f5f7fa;padding:32px 16px;">
+        <tr>
+            <td align="center">
+                <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width:640px;background-color:#ffffff;border-radius:18px;padding:40px 36px;box-shadow:0 25px 60px rgba(15,23,42,0.12);">
+                    <tr>
+                        <td style="padding-bottom:24px;text-align:left;">
+                            <div style="font-size:18px;font-weight:700;color:#0f172a;">{$siteName}</div>
+                            <div style="font-size:13px;color:#6b7280;">{$context['subject']}</div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="font-size:15px;line-height:1.7;color:#111827;">
+                            {$content}
+                        </td>
+                    </tr>
+                </table>
+                <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width:640px;margin-top:16px;">
+                    <tr>
+                        <td style="text-align:center;color:#9ca3af;font-size:12px;line-height:1.6;">
+                            <p style="margin:0 0 6px;">© {$year} {$siteName}. All rights reserved.</p>
+                            {$unsubscribeBlock}
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>
+HTML;
+}
+
+/**
+ * Merge template tags for both HTML and plain text versions.
+ *
+ * @param string $template  Template body.
+ * @param array  $context   Context key/value pairs.
+ * @param bool   $allowHtml Whether HTML entities should be preserved.
+ */
+function email_merge_tags(string $template, array $context, bool $allowHtml = false): string
+{
+    $replacements = [];
+    foreach ($context as $key => $value) {
+        $placeholder = '{{' . $key . '}}';
+        $replacements[$placeholder] = $allowHtml ? (string) $value : html_entity_decode((string) $value, ENT_QUOTES, 'UTF-8');
+    }
+
+    return strtr($template, $replacements);
+}
+
+/**
+ * Render the final HTML and plain text bodies for a message.
+ *
+ * @param string $contentHtml HTML fragment provided by admin.
+ * @param string $contentText Plain text template provided by admin.
+ * @param array  $context     Context values available to templates.
+ * @param string $preheader   Hidden preview text.
+ *
+ * @return array{0:string,1:string}
+ */
+function email_render_bodies(string $contentHtml, string $contentText, array $context, string $preheader = ''): array
+{
+    $html = email_wrap_html($contentHtml, $preheader, $context);
+
+    $textTemplate = $contentText !== '' ? $contentText : strip_tags($contentHtml);
+    $textTemplate = preg_replace('/<br\s*\/?>(\r?\n)?/i', "\n", $textTemplate);
+    $textTemplate = html_entity_decode(strip_tags($textTemplate), ENT_QUOTES, 'UTF-8');
+
+    $text = email_merge_tags($textTemplate, $context);
+
+    $text = preg_replace("/\n{3,}/", "\n\n", trim($text));
+
+    return [$html, $text];
+}

--- a/includes/newsletter_helpers.php
+++ b/includes/newsletter_helpers.php
@@ -1,0 +1,90 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+
+/**
+ * Generate a verification token for newsletter subscriptions.
+ */
+function newsletter_generate_verification_token(): string
+{
+    return bin2hex(random_bytes(32));
+}
+
+/**
+ * Build a verification URL for the subscriber.
+ */
+function newsletter_verification_url(string $email, string $token): string
+{
+    return SITE_URL . '/newsletter-manage.php?action=verify&email=' . rawurlencode($email) . '&token=' . rawurlencode($token);
+}
+
+/**
+ * Generate a signed unsubscribe token for the provided email.
+ */
+function newsletter_generate_unsubscribe_token(string $email): string
+{
+    $normalized = strtolower(trim($email));
+    return hash_hmac('sha256', $normalized . '|unsubscribe', SITE_SECRET_KEY);
+}
+
+/**
+ * Build the unsubscribe management URL.
+ */
+function newsletter_unsubscribe_url(string $email): string
+{
+    $token = newsletter_generate_unsubscribe_token($email);
+
+    return SITE_URL . '/newsletter-manage.php?action=unsubscribe&email=' . rawurlencode($email) . '&token=' . $token;
+}
+
+/**
+ * Dispatch a confirmation email using the centralised template system.
+ */
+function newsletter_send_confirmation_email(MailService $mailer, string $email, string $verificationToken): void
+{
+    require_once __DIR__ . '/email_template.php';
+
+    $verificationUrl = newsletter_verification_url($email, $verificationToken);
+    $unsubscribeUrl = newsletter_unsubscribe_url($email);
+
+    $context = email_build_context([
+        'subject' => 'Confirm your subscription',
+        'preheader' => 'Click to confirm your subscription to ' . SITE_NAME,
+        'unsubscribe_url' => $unsubscribeUrl,
+    ]);
+
+    $context['verification_url'] = htmlspecialchars($verificationUrl, ENT_QUOTES, 'UTF-8');
+    $context['verification_url_plain'] = $verificationUrl;
+
+    $htmlTemplate = <<<HTML
+<p>Hi {{name}},</p>
+<p>Thanks for joining the {{site_name}} insider list.</p>
+<p style="margin:24px 0;"><a href="{{verification_url}}" style="background-color:#2563eb;color:#ffffff;padding:14px 28px;border-radius:999px;text-decoration:none;font-weight:600;">Confirm my email</a></p>
+<p>If the button above does not work, copy and paste this link into your browser:</p>
+<p style="word-break:break-all;">{{verification_url}}</p>
+<p>This extra step ensures nobody can sign you up without permission.</p>
+HTML;
+
+    $textTemplate = <<<TEXT
+Hi {{name}},
+
+Thanks for joining the {{site_name}} insider list. Confirm your address by visiting: {{verification_url_plain}}
+
+If you didn't request this, you can ignore the email.
+TEXT;
+
+    [$htmlBody, $textBody] = email_render_bodies($htmlTemplate, $textTemplate, $context, $context['preheader']);
+
+    $mailer->send(
+        [['email' => $email, 'name' => '']],
+        '[' . SITE_NAME . '] Confirm your subscription',
+        $htmlBody,
+        [
+            'text' => $textBody,
+            'reply_to' => ['email' => SITE_EMAIL, 'name' => SITE_NAME],
+            'list_unsubscribe' => [$unsubscribeUrl, 'mailto:' . SITE_EMAIL],
+            'list_unsubscribe_post' => true,
+            'custom_headers' => ['X-Subscription-Flow' => 'newsletter-confirm'],
+        ]
+    );
+}
+

--- a/newsletter-manage.php
+++ b/newsletter-manage.php
@@ -1,0 +1,118 @@
+<?php
+require_once __DIR__ . '/config/config.php';
+require_once __DIR__ . '/config/database.php';
+require_once __DIR__ . '/includes/newsletter_helpers.php';
+
+$database = new Database();
+$db = $database->getConnection();
+
+$action = $_GET['action'] ?? '';
+$email = trim((string) ($_GET['email'] ?? ''));
+$token = trim((string) ($_GET['token'] ?? ''));
+
+$status = 'error';
+$title = 'Newsletter preferences';
+$message = 'Invalid request. Please double-check your link and try again.';
+$extraContent = '';
+
+if ($email !== '' && !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    $message = 'The email address supplied is not valid.';
+} else {
+    switch ($action) {
+        case 'verify':
+            if ($email === '' || $token === '') {
+                $message = 'Verification details are missing.';
+                break;
+            }
+
+            $stmt = $db->prepare('SELECT id, verification_token, verified_at, is_active FROM newsletter_subscriptions WHERE email = :email LIMIT 1');
+            $stmt->execute([':email' => $email]);
+            $subscription = $stmt->fetch(PDO::FETCH_ASSOC);
+
+            if (!$subscription) {
+                $message = 'We could not find your subscription. Please subscribe again from the newsletter page.';
+                break;
+            }
+
+            if (empty($subscription['verification_token']) || !hash_equals($subscription['verification_token'], $token)) {
+                $message = 'This verification link has expired or is invalid. You can request a new one by subscribing again.';
+                break;
+            }
+
+            $update = $db->prepare('UPDATE newsletter_subscriptions SET verified_at = NOW(), is_active = 1, verification_token = NULL, updated_at = NOW() WHERE id = :id');
+            $update->execute([':id' => (int) $subscription['id']]);
+
+            $status = 'success';
+            $title = 'Subscription confirmed';
+            $message = 'Thank you! Your email address has been verified and you will now receive our newsletter.';
+            $extraContent = '<p class="mb-0">Need to unsubscribe later? You will find a quick link at the bottom of every email we send.</p>';
+            break;
+
+        case 'unsubscribe':
+            if ($email === '' || $token === '') {
+                $message = 'Missing unsubscribe details.';
+                break;
+            }
+
+            $expected = newsletter_generate_unsubscribe_token($email);
+            if (!hash_equals($expected, $token)) {
+                $message = 'This unsubscribe link is no longer valid. Please use the most recent email we sent you.';
+                break;
+            }
+
+            $stmt = $db->prepare('SELECT id, is_active FROM newsletter_subscriptions WHERE email = :email LIMIT 1');
+            $stmt->execute([':email' => $email]);
+            $subscription = $stmt->fetch(PDO::FETCH_ASSOC);
+
+            if ($subscription) {
+                $update = $db->prepare('UPDATE newsletter_subscriptions SET is_active = 0, updated_at = NOW() WHERE id = :id');
+                $update->execute([':id' => (int) $subscription['id']]);
+            } else {
+                $insert = $db->prepare('INSERT INTO newsletter_subscriptions (email, preferences, is_active, created_at, updated_at) VALUES (:email, :preferences, 0, NOW(), NOW())');
+                $insert->execute([
+                    ':email' => $email,
+                    ':preferences' => json_encode([]),
+                ]);
+            }
+
+            $status = 'success';
+            $title = 'You have been unsubscribed';
+            $message = 'You will no longer receive marketing emails from us. We are sorry to see you go.';
+            $extraContent = '<p class="mb-0">Changed your mind? <a href="' . htmlspecialchars(SITE_URL . '/newsletter.php', ENT_QUOTES, 'UTF-8') . '">Subscribe again</a> at any time.</p>';
+            break;
+
+        default:
+            $message = 'This management link has expired or is incorrect.';
+    }
+}
+
+$page_title = $title . ' - ' . SITE_NAME;
+include __DIR__ . '/includes/header.php';
+?>
+
+<div class="page-wrapper flex-grow-1 py-5">
+    <div class="container" style="max-width:720px;">
+        <div class="glass-card p-4 p-lg-5 text-center animate-fade-in">
+            <div class="mb-4">
+                <?php if ($status === 'success'): ?>
+                    <div class="rounded-circle bg-success bg-opacity-10 text-success mx-auto d-flex align-items-center justify-content-center" style="width:72px;height:72px;">
+                        <i class="fas fa-check fa-2x"></i>
+                    </div>
+                <?php else: ?>
+                    <div class="rounded-circle bg-warning bg-opacity-10 text-warning mx-auto d-flex align-items-center justify-content-center" style="width:72px;height:72px;">
+                        <i class="fas fa-exclamation fa-2x"></i>
+                    </div>
+                <?php endif; ?>
+            </div>
+            <h1 class="text-white fw-bold mb-3"><?php echo htmlspecialchars($title, ENT_QUOTES, 'UTF-8'); ?></h1>
+            <p class="text-muted mb-4"><?php echo htmlspecialchars($message, ENT_QUOTES, 'UTF-8'); ?></p>
+            <?php if ($extraContent !== ''): ?>
+                <div class="text-muted">
+                    <?php echo $extraContent; ?>
+                </div>
+            <?php endif; ?>
+        </div>
+    </div>
+</div>
+
+<?php include __DIR__ . '/includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- route all admin newsletter and manual email sends through the shared SMTP MailService with professional HTML/text templating and List-Unsubscribe headers
- add reusable email template helpers, TinyMCE-powered WYSIWYG editors, and preheader/plain-text controls so admins can design compliant campaigns
- implement double opt-in confirmation, inbox-friendly verification notices, and a public unsubscribe management page for subscribers
- harden MailService with Message-ID/origin headers, return-path handling, and fallback improvements to mirror trusted support delivery
- ensure new members automatically receive the Newcomer badge by updating achievements during registration/login and assigning a default active badge
- connect the forgot password form to the configured hCaptcha keys with a resilient verification request and secure site-key rendering

## Testing
- php -l includes/auth.php
- php -l forgot-password.php

------
https://chatgpt.com/codex/tasks/task_e_68e6dcc4dc548329b84ece147e4c2456